### PR TITLE
feat: Criado a função limpaBuffer

### DIFF
--- a/source/funcoes.h
+++ b/source/funcoes.h
@@ -3,6 +3,7 @@
 
 typedef struct{
 
+    int usuarioId;
     char nome[50];
     char CPF[12];
     char senha[50];
@@ -12,6 +13,7 @@ typedef struct{
 
 typedef struct{
 
+    int livroId;
     char titulo[50];
     char autor[50];
     char editora[50];
@@ -22,6 +24,7 @@ typedef struct{
 }Livro;
 
 int exibirMenuVisitante();
+void limpabuffer();
 
 
 #endif

--- a/source/limpaBuffer.c
+++ b/source/limpaBuffer.c
@@ -1,0 +1,6 @@
+#include <stdio.h>
+
+void limpaBuffer(){
+    char c;
+    while((c = getchar()) != '\n' && c != EOF);
+}


### PR DESCRIPTION
A função limpaBuffer consome os caracteres do buffer até achar um \n ou um EOF. Utilizada principalmente antes da função fgets()