### PR TITLE
fix: tratamento de caracter no cadastro

### DIFF
--- a/source/cadastrarUsuario.c
+++ b/source/cadastrarUsuario.c
@@ -66,7 +66,6 @@ int verificarCPF(Usuario *ptrUsuario){
         printf("\n");
     } while(tamanhoCPF != 12 || !numerico);
 
-    CPF[tamanhoCPF-1] = '\0';
     strcpy(ptrUsuario->CPF, CPF);
 
     return 0;


### PR DESCRIPTION
Removido o tratamento para remover o caracter '\n' do CPF no registro para correção de bugs.